### PR TITLE
Added .Values.disableAdminPanelReadinessProbe to prevent httpGet readinessProbe to admin panel

### DIFF
--- a/charts/yourls/Chart.yaml
+++ b/charts/yourls/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: yourls
 description: Your Own URL Shortener
-version: 1.1.2
+version: 1.1.3
 appVersion: 1.7.3
 keywords:
   - shortener

--- a/charts/yourls/README.md
+++ b/charts/yourls/README.md
@@ -80,6 +80,7 @@ The following table lists the configurable parameters of the YOURLS chart and th
 | `nodePorts.http`                 | Kubernetes http node port                  | `""`                                                    |
 | `nodePorts.https`                | Kubernetes https node port                 | `""`                                                    |
 | `healthcheckHttps`               | Use https for liveliness and readiness     | `false`                                                 |
+| `disableAdminPanelReadinessProbe`| Disable readinessProbe.httpGet to /admin/  | `false`                                                 |
 | `ingress.enabled`                | Enable ingress controller resource         | `false`                                                 |
 | `ingress.certManager`            | Add annotations for cert-manager           | `false`                                                 |
 | `ingress.annotations`            | Ingress annotations                        | `[]`                                                    |

--- a/charts/yourls/templates/deployment.yaml
+++ b/charts/yourls/templates/deployment.yaml
@@ -102,6 +102,7 @@ spec:
             {{- end }}
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
+          {{- if not .Values.disableAdminPanelReadinessProbe }}
             httpGet:
               path: /admin/
             {{- if not .Values.healthcheckHttps }}
@@ -111,6 +112,7 @@ spec:
               scheme: HTTPS
             {{- end }}
             {{- toYaml .Values.readinessProbe | nindent 12 }}
+          {{- end }}}
           volumeMounts:
             - mountPath: /var/www/html
               name: yourls-data

--- a/charts/yourls/templates/deployment.yaml
+++ b/charts/yourls/templates/deployment.yaml
@@ -112,7 +112,7 @@ spec:
               scheme: HTTPS
             {{- end }}
             {{- toYaml .Values.readinessProbe | nindent 12 }}
-          {{- end }}}
+          {{- end }}
           volumeMounts:
             - mountPath: /var/www/html
               name: yourls-data

--- a/charts/yourls/values.yaml
+++ b/charts/yourls/values.yaml
@@ -127,6 +127,9 @@ service:
 ## Allow health checks to be pointed at the https port
 healthcheckHttps: false
 
+## Disables readiness probe
+disableAdminPanelReadinessProbe: false
+
 ## Configure extra options for liveness and readiness probes
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
 livenessProbe:


### PR DESCRIPTION
During an installation to a Kubernetes cluster I faced an issue that a deployed POD has been marked as not ready all the time due to a 503 error from admin panel. 503 error came from a fact that Nginx Ingress controller can't proxy not ready pods.

As soon as I've disabled readinessProbe.httpGet that triggers requests to admin panel, a pod has been marked ready and Ingress could proxy application.