### PR TITLE
Allow an existing secret to be used

### DIFF
--- a/charts/yourls/Chart.yaml
+++ b/charts/yourls/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: yourls
 description: Your Own URL Shortener
-version: 1.2.0
+version: 1.3.0
 appVersion: 1.7.4
 keywords:
   - shortener

--- a/charts/yourls/templates/_helpers.tpl
+++ b/charts/yourls/templates/_helpers.tpl
@@ -4,7 +4,7 @@ Expand the name of the chart.
 */}}
 {{- define "yourls.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
- {{- end -}}
+{{- end -}}
 
 {{/*
 Create a default fully qualified app name.

--- a/charts/yourls/templates/_helpers.tpl
+++ b/charts/yourls/templates/_helpers.tpl
@@ -4,7 +4,7 @@ Expand the name of the chart.
 */}}
 {{- define "yourls.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+ {{- end -}}
 
 {{/*
 Create a default fully qualified app name.
@@ -61,4 +61,20 @@ Return the proper image name (for the metrics image)
 {{- $repositoryName := .Values.metrics.image.repository -}}
 {{- $tag := .Values.metrics.image.tag | toString -}}
 {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- end -}}
+
+{{/*
+Return secret name to be used for application secrets
+*/}}
+{{- define "yourls.applicationSecret" -}}
+{{- $fullName := include "yourls.fullname" . -}}
+{{- default $fullName .Values.yourlsPasswordExistingSecret | quote -}}
+{{- end -}}
+
+{{/*
+Return secret name to be used for external db secrets
+*/}}
+{{- define "yourls.externalDatabaseSecret" -}}
+{{- $fullName := printf "%s-%s" .Chart.Name "externaldb" -}}
+{{- default $fullName .Values.externalDatabase.existingSecret | quote -}}
 {{- end -}}

--- a/charts/yourls/templates/deployment.yaml
+++ b/charts/yourls/templates/deployment.yaml
@@ -69,7 +69,7 @@ spec:
                   name: {{ template "mariadb.fullname" . }}
                   key: mariadb-password
                 {{- else }}
-                  name: {{ printf "%s-%s" .Release.Name "externaldb" }}
+                  name: {{ template "yourls.externalDatabaseSecret" . }}
                   key: db-password
                 {{- end }}
             - name: YOURLS_DB_PREFIX
@@ -81,7 +81,7 @@ spec:
             - name: YOURLS_PASS
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "yourls.fullname" . }}
+                  name: {{ template "yourls.applicationSecret" . }}
                   key: yourls-password
           {{- if .Values.extraEnv }}
             {{- toYaml .Values.extraEnv | nindent 12 }}

--- a/charts/yourls/templates/externaldb-secrets.yaml
+++ b/charts/yourls/templates/externaldb-secrets.yaml
@@ -1,8 +1,9 @@
 {{- if not .Values.mariadb.enabled }}
+{{- if not .Values.externalDatabase.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-%s" .Release.Name "externaldb"  }}
+  name: {{ template "yourls.externalDatabaseSecret" . }}
   labels:
     app: {{ printf "%s-%s" .Release.Name "externaldb"  }}
     chart: "{{ template "yourls.chart" . }}"
@@ -11,4 +12,5 @@ metadata:
 type: Opaque
 data:
   db-password: {{ .Values.externalDatabase.password | b64enc | quote }}
+{{- end }}
 {{- end }}

--- a/charts/yourls/templates/secrets.yaml
+++ b/charts/yourls/templates/secrets.yaml
@@ -1,7 +1,8 @@
+{{- if not .Values.yourlsPasswordExistingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "yourls.fullname" . }}
+  name: {{ template "yourls.applicationSecret" . }}
   labels:
     app: "{{ template "yourls.fullname" . }}"
     chart: "{{ template "yourls.chart" . }}"
@@ -14,3 +15,4 @@ data:
   {{- else }}
   yourls-password: {{ randAlphaNum 10 | b64enc | quote }}
   {{- end }}
+{{- end }}

--- a/charts/yourls/values.yaml
+++ b/charts/yourls/values.yaml
@@ -34,6 +34,10 @@ yourlsUsername: user
 ##
 # yourlsPassword:
 
+## Existing secret with application password
+## If set, yourlsPassword is ignored
+# yourlsPasswordExistingSecret:
+
 ## Table prefix
 ## ref: https://hub.docker.com/_/yourls
 ##
@@ -63,6 +67,9 @@ externalDatabase:
 
   ## Database password
   password: ""
+
+  ## Use an existing secret with the database password
+  # existingSecret:
 
   ## Database name
   database: yourls


### PR DESCRIPTION
## what

Allow an existing secret to be used instead of always creating one

## why

Some workflows prefer managing secrets separately from the application. For example using sops secrets 

## testing

- Installed chart without this change and then performed a diff with this change applied. The diff was clean except for added quotes around references to secrets
- Set `yourlsPasswordExistingSecret` and `externalDatabase.existingSecret`. The two secrets were deleted, and the references were updated to use the provided values
