### PR TITLE
fix: prefix access to .Values in range with $

### DIFF
--- a/charts/yourls/Chart.yaml
+++ b/charts/yourls/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 2.2.3
+version: 2.2.4
 name: yourls
 description: Your Own URL Shortener
 appVersion: "1.8.2"

--- a/charts/yourls/templates/ingress.yaml
+++ b/charts/yourls/templates/ingress.yaml
@@ -24,8 +24,8 @@ spec:
         - path: {{ default "/" .path }}
           backend:
             serviceName: "{{ template "yourls.fullname" $ }}"
-            {{- if .Values.service }}{{ if .Values.service.port }}
-            servicePort: {{ .Values.service.port }}
+            {{- if $.Values.service }}{{ if $.Values.service.port }}
+            servicePort: {{ $.Values.service.port }}
             {{- end }}{{ else }}
             servicePort: 80
             {{- end }}


### PR DESCRIPTION
In a `{{ range }}`, the access to `{{ .Values }}` has to be prefixed with a `$`, so that the top-level `.Values` is used. 

Otherwise, this template leads to a

```
Error: Failed to render chart: exit status 1: Error: template: yourls/templates/ingress.yaml:27:26: executing "yourls/templates/ingress.yaml" at <.Values.service>: nil pointer evaluating interface {}.service
```