### PR TITLE
Use MariaDB and enable chart testing on upgrades

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - prepare
     uses: ./.github/workflows/test.yml
     with:
-      action-matrix: '["lint", "install"]'
+      action-matrix: '["lint", "install", "install --upgrade"]'
 
   release:
     name: Release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
     name: Run chart-testing
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         action: ${{ fromJSON(inputs.action-matrix) }}
     steps:

--- a/charts/yourls/Chart.lock
+++ b/charts/yourls/Chart.lock
@@ -2,8 +2,8 @@ dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 1.11.2
-- name: mysql
+- name: mariadb
   repository: https://charts.bitnami.com/bitnami
-  version: 8.8.26
-digest: sha256:8294418f1cfe24be0aca1a9765685e84c1241cfd73ba3782b668e7b9baf66b40
-generated: "2022-02-28T14:41:29.745991659Z"
+  version: 10.3.7
+digest: sha256:6548fe4dc99b11ca92de8b08291cd33f55abf9629ea88f1ca990714d6813ce8a
+generated: "2022-02-28T22:45:20.7698355+01:00"

--- a/charts/yourls/Chart.yaml
+++ b/charts/yourls/Chart.yaml
@@ -40,7 +40,14 @@ annotations:
     fingerprint: 6FCD850E18E4A4FF76DD1184A3A42A61961E423F
     url: https://yourls.org/.well-known/openpgpkey/hu/6e4gbtp15q1znf3unweeducn7urty4mr
   artifacthub.io/changes: |
+    - kind: changed
+      description: Switch to MariaDB as database engine
+      links:
+        - name: GitHub PR
+          url: https://github.com/YOURLS/charts/pull/126
+    - kind: changed
+      description: Values namespace `mysql` rename to `mariadb`
+    - kind: added
+      description: Database chart values validation
     - kind: added
       description: Chart upgrade validation
-    - kind: changed
-      description: Switched to MariaDB in place of MySQL (values under namespace are compatible)

--- a/charts/yourls/Chart.yaml
+++ b/charts/yourls/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-version: 4.2.7
+version: 5.0.0
 name: yourls
 description: Your Own URL Shortener
-appVersion: "1.8.2"
+appVersion: "1.9.0"
 type: application
 keywords:
   - shortener
@@ -42,3 +42,7 @@ annotations:
   artifacthub.io/changes: |
     - kind: added
       description: Chart upgrade validation
+    - kind: changed
+      description: Switched to MariaDB in place of MySQL (values under namespace are compatible)
+    - kind: changed
+      description: Bump YOURLS to v1.9.0

--- a/charts/yourls/Chart.yaml
+++ b/charts/yourls/Chart.yaml
@@ -25,10 +25,10 @@ dependencies:
     version: ^1.11.2
     tags:
       - bitnami-common
-  - condition: mysql.enabled
-    name: mysql
+  - condition: mariadb.enabled
+    name: mariadb
     repository: https://charts.bitnami.com/bitnami
-    version: ^8.8.26
+    version: ^10.3.7
     tags:
       - yourls-database
 annotations:

--- a/charts/yourls/Chart.yaml
+++ b/charts/yourls/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 4.2.6
+version: 4.2.7
 name: yourls
 description: Your Own URL Shortener
 appVersion: "1.8.2"
@@ -40,10 +40,5 @@ annotations:
     fingerprint: 6FCD850E18E4A4FF76DD1184A3A42A61961E423F
     url: https://yourls.org/.well-known/openpgpkey/hu/6e4gbtp15q1znf3unweeducn7urty4mr
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Bug fix for MySQL validation
-      links:
-        - name: GitHub Issue
-          url: https://github.com/YOURLS/charts/issues/120
-        - name: GitHub Pull Request
-          url: https://github.com/YOURLS/charts/pull/123
+    - kind: added
+      description: Chart upgrade validation

--- a/charts/yourls/README.md
+++ b/charts/yourls/README.md
@@ -7,8 +7,8 @@
 This chart installs the [YOURLS](https://yourls.org) app on a [Kubernetes](https://kubernetes.io) cluster
 using the [Helm](https://helm.sh) package manager.
 
-It includes the [MySQL chart](https://artifacthub.io/packages/helm/bitnami/mysql) which is required for
-bootstrapping a MySQL deployment for the database requirements of the YOURLS application.
+It includes the [MariaDB chart](https://artifacthub.io/packages/helm/bitnami/mariadb) which is required for
+bootstrapping a MariaDB deployment for the database requirements of the YOURLS application.
 
 ## Prerequisites
 
@@ -43,11 +43,11 @@ The `yourls` parameters map to the env variables defined in [YOURLS](https://hub
 
 _For more information please refer to the [YOURLS](https://hub.docker.com/_/yourls) image documentation._
 
-### MySQL
+### MariaDB
 
-The `mysql` parameters map to [MySQL sub-chart](https://artifacthub.io/packages/helm/bitnami/mysql) parameters.
+The `mariadb` parameters map to [MariaDB sub-chart](https://artifacthub.io/packages/helm/bitnami/mariadb) parameters.
 
-_For more information please refer to the [MySQL parameters](https://artifacthub.io/packages/helm/bitnami/mysql#parameters) documentation._
+_For more information please refer to the [MariaDB parameters](https://artifacthub.io/packages/helm/bitnami/mariadb#parameters) documentation._
 
 ## Persistence
 
@@ -59,14 +59,14 @@ Sometimes you may want to have YOURLS connect to an external database rather tha
 to use a managed database service, or use run a single database server for all your applications.
 
 To do this, the chart allows you to specify credentials for an external database under the `externalDatabase` parameter.
-You should also disable the MySQL installation with the `mysql.enabled` option. For example:
+You should also disable the MariaDB installation with the `mariadb.enabled` option. For example:
 
 ```console
 helm install yourls/yourls \
-  --set mysql.enabled=false,externalDatabase.host=myexternalhost,externalDatabase.user=myuser,externalDatabase.password=mypassword,externalDatabase.database=mydatabase
+  --set mariadb.enabled=false,externalDatabase.host=myexternalhost,externalDatabase.user=myuser,externalDatabase.password=mypassword,externalDatabase.database=mydatabase
 ```
 
-Note also if you disable MySQL per above you MUST supply values for the `externalDatabase` connection.
+Note also if you disable MariaDB per above you MUST supply values for the `externalDatabase` connection.
 
 ## Ingress
 

--- a/charts/yourls/ci/ct-values.yaml
+++ b/charts/yourls/ci/ct-values.yaml
@@ -4,7 +4,7 @@ service:
 yourls:
   password: "test-yourls"
 
-mysql:
+mariadb:
   auth:
     rootPassword: "test-root"
     password: "test-user"

--- a/charts/yourls/ci/ct-values.yaml
+++ b/charts/yourls/ci/ct-values.yaml
@@ -1,2 +1,10 @@
 service:
   type: ClusterIP
+
+yourls:
+  password: "test-yourls"
+
+mysql:
+  auth:
+    rootPassword: "test-root"
+    password: "test-user"

--- a/charts/yourls/ci/ingress-wildcard-values.yaml
+++ b/charts/yourls/ci/ingress-wildcard-values.yaml
@@ -7,3 +7,11 @@ ingress:
   extraHosts:
     - name: "*.domain.tld"
       path: /
+
+yourls:
+  password: "test-yourls"
+
+mysql:
+  auth:
+    rootPassword: "test-root"
+    password: "test-user"

--- a/charts/yourls/ci/ingress-wildcard-values.yaml
+++ b/charts/yourls/ci/ingress-wildcard-values.yaml
@@ -11,7 +11,7 @@ ingress:
 yourls:
   password: "test-yourls"
 
-mysql:
+mariadb:
   auth:
     rootPassword: "test-root"
     password: "test-user"

--- a/charts/yourls/ci/metrics-and-ingress-values.yaml
+++ b/charts/yourls/ci/metrics-and-ingress-values.yaml
@@ -11,7 +11,7 @@ metrics:
 yourls:
   password: "test-yourls"
 
-mysql:
+mariadb:
   auth:
     rootPassword: "test-root"
     password: "test-user"

--- a/charts/yourls/ci/metrics-and-ingress-values.yaml
+++ b/charts/yourls/ci/metrics-and-ingress-values.yaml
@@ -7,3 +7,11 @@ service:
 
 metrics:
   enabled: true
+
+yourls:
+  password: "test-yourls"
+
+mysql:
+  auth:
+    rootPassword: "test-root"
+    password: "test-user"

--- a/charts/yourls/templates/NOTES.txt
+++ b/charts/yourls/templates/NOTES.txt
@@ -96,11 +96,9 @@ You can access Apache Prometheus metrics following the steps below:
     {{- $yourlsPasswordValidationErrors := include "common.validations.values.single.empty" $yourlsPassword -}}
     {{- $passwordValidationErrors = append $passwordValidationErrors $yourlsPasswordValidationErrors -}}
 {{- end }}
-{{- if .Values.mysql.enabled }}
-{{/* TODO: Validate MySQL
-    {{- $mysqlSecretName := include "yourls.databaseSecretName" . -}}
-    {{- $mysqlPasswordValidationErrors := include "common.validations.values.mariadb.passwords" (dict "secret" $mysqlSecretName "subchart" true "context" $) -}}
-    {{- $passwordValidationErrors = append $passwordValidationErrors $mysqlPasswordValidationErrors -}}
-*/}}
+{{- if .Values.mariadb.enabled }}
+    {{- $mariadbSecretName := include "yourls.databaseSecretName" . -}}
+    {{- $mariadbPasswordValidationErrors := include "common.validations.values.mariadb.passwords" (dict "secret" $mariadbSecretName "subchart" true "context" $) -}}
+    {{- $passwordValidationErrors = append $passwordValidationErrors $mariadbPasswordValidationErrors -}}
 {{- end }}
 {{- include "common.errors.upgrade.passwords.empty" (dict "validationErrors" $passwordValidationErrors "context" $) -}}

--- a/charts/yourls/templates/_helpers.tpl
+++ b/charts/yourls/templates/_helpers.tpl
@@ -4,8 +4,8 @@
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "yourls.mysql.fullname" -}}
-{{- include "common.names.dependency.fullname" (dict "chartName" "mysql" "chartValues" .Values.mysql "context" $) -}}
+{{- define "yourls.mariadb.fullname" -}}
+{{- include "common.names.dependency.fullname" (dict "chartName" "mariadb" "chartValues" .Values.mariadb "context" $) -}}
 {{- end -}}
 
 {{/*
@@ -42,14 +42,14 @@ Return the proper Docker Image Registry Secret Names
 {{- end -}}
 
 {{/*
-Return the MySQL Hostname
+Return the MariaDB Hostname
 */}}
 {{- define "yourls.databaseHost" -}}
-{{- if .Values.mysql.enabled }}
-    {{- if eq .Values.mysql.architecture "replication" }}
-        {{- printf "%s-primary" (include "yourls.mysql.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- if .Values.mariadb.enabled }}
+    {{- if eq .Values.mariadb.architecture "replication" }}
+        {{- printf "%s-primary" (include "yourls.mariadb.fullname" .) | trunc 63 | trimSuffix "-" -}}
     {{- else -}}
-        {{- printf "%s" (include "yourls.mysql.fullname" .) -}}
+        {{- printf "%s" (include "yourls.mariadb.fullname" .) -}}
     {{- end -}}
 {{- else -}}
     {{- printf "%s" .Values.externalDatabase.host -}}
@@ -57,10 +57,10 @@ Return the MySQL Hostname
 {{- end -}}
 
 {{/*
-Return the MySQL Port
+Return the MariaDB Port
 */}}
 {{- define "yourls.databasePort" -}}
-{{- if .Values.mysql.enabled }}
+{{- if .Values.mariadb.enabled }}
     {{- printf "3306" -}}
 {{- else -}}
     {{- printf "%d" (.Values.externalDatabase.port | int ) -}}
@@ -68,36 +68,36 @@ Return the MySQL Port
 {{- end -}}
 
 {{/*
-Return the MySQL Database Name
+Return the MariaDB Database Name
 */}}
 {{- define "yourls.databaseName" -}}
-{{- if .Values.mysql.enabled }}
-    {{- printf "%s" .Values.mysql.auth.database -}}
+{{- if .Values.mariadb.enabled }}
+    {{- printf "%s" .Values.mariadb.auth.database -}}
 {{- else -}}
     {{- printf "%s" .Values.externalDatabase.database -}}
 {{- end -}}
 {{- end -}}
 
 {{/*
-Return the MySQL User
+Return the MariaDB User
 */}}
 {{- define "yourls.databaseUser" -}}
-{{- if .Values.mysql.enabled }}
-    {{- printf "%s" .Values.mysql.auth.username -}}
+{{- if .Values.mariadb.enabled }}
+    {{- printf "%s" .Values.mariadb.auth.username -}}
 {{- else -}}
     {{- printf "%s" .Values.externalDatabase.user -}}
 {{- end -}}
 {{- end -}}
 
 {{/*
-Return the MySQL Secret Name
+Return the MariaDB Secret Name
 */}}
 {{- define "yourls.databaseSecretName" -}}
-{{- if .Values.mysql.enabled }}
-    {{- if .Values.mysql.auth.existingSecret -}}
-        {{- printf "%s" .Values.mysql.auth.existingSecret -}}
+{{- if .Values.mariadb.enabled }}
+    {{- if .Values.mariadb.auth.existingSecret -}}
+        {{- printf "%s" .Values.mariadb.auth.existingSecret -}}
     {{- else -}}
-        {{- printf "%s" (include "yourls.mysql.fullname" .) -}}
+        {{- printf "%s" (include "yourls.mariadb.fullname" .) -}}
     {{- end -}}
 {{- else if .Values.externalDatabase.existingSecret -}}
     {{- printf "%s" .Values.externalDatabase.existingSecret -}}
@@ -139,9 +139,9 @@ Compile all warnings into a single message.
 
 {{/* Validate values of YOURLS - Database */}}
 {{- define "yourls.validateValues.database" -}}
-{{- if and (not .Values.mysql.enabled) (or (empty .Values.externalDatabase.host) (empty .Values.externalDatabase.port) (empty .Values.externalDatabase.database)) -}}
+{{- if and (not .Values.mariadb.enabled) (or (empty .Values.externalDatabase.host) (empty .Values.externalDatabase.port) (empty .Values.externalDatabase.database)) -}}
 yourls: database
-   You disable the MySQL installation but you did not provide the required parameters
+   You disable the MariaDB installation but you did not provide the required parameters
    to use an external database. To use an external database, please ensure you provide
    (at least) the following values:
 

--- a/charts/yourls/templates/deployment.yaml
+++ b/charts/yourls/templates/deployment.yaml
@@ -115,9 +115,9 @@ spec:
               value: {{ ternary "true" "false" (or .Values.image.debug .Values.diagnosticMode.enabled) | quote }}
             - name: ALLOW_EMPTY_PASSWORD
               value: {{ ternary "yes" "no" .Values.allowEmptyPassword | quote }}
-            - name: MYSQL_HOST
+            - name: MARIADB_HOST
               value: {{ include "yourls.databaseHost" . | quote }}
-            - name: MYSQL_PORT_NUMBER
+            - name: MARIADB_PORT_NUMBER
               value: {{ include "yourls.databasePort" . | quote }}
             - name: YOURLS_DB_HOST
               value: {{ include "yourls.databaseHost" . | quote }}
@@ -129,7 +129,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "yourls.databaseSecretName" . }}
-                  key: mysql-password
+                  key: mariadb-password
             - name: YOURLS_DB_PREFIX
               value: {{ .Values.yourls.tablePrefix | quote }}
             - name: YOURLS_SITE

--- a/charts/yourls/templates/externaldb-secrets.yaml
+++ b/charts/yourls/templates/externaldb-secrets.yaml
@@ -1,4 +1,4 @@
-{{- if not (or .Values.mysql.enabled .Values.externalDatabase.existingSecret) }}
+{{- if not (or .Values.mariadb.enabled .Values.externalDatabase.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -13,5 +13,5 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  mysql-password: {{ .Values.externalDatabase.password | b64enc | quote }}
+  mariadb-password: {{ .Values.externalDatabase.password | b64enc | quote }}
 {{- end }}

--- a/charts/yourls/values.schema.json
+++ b/charts/yourls/values.schema.json
@@ -228,19 +228,19 @@
         }
       }
     },
-    "mysql": {
-      "title": "MySQL chart configuration",
-      "description": "https://artifacthub.io/packages/helm/bitnami/mysql",
+    "mariadb": {
+      "title": "MariaDB chart configuration",
+      "description": "https://artifacthub.io/packages/helm/bitnami/mariadb",
       "allOf": [
         {
-          "$ref": "https://raw.githubusercontent.com/bitnami/charts/master/bitnami/mysql/values.schema.json"
+          "$ref": "https://raw.githubusercontent.com/bitnami/charts/master/bitnami/mariadb/values.schema.json"
         },
         {
           "properties": {
             "enabled": {
               "type": "boolean",
               "default": true,
-              "description": "Deploy a MySQL server to satisfy the application database"
+              "description": "Deploy a MariaDB server to satisfy the application database"
             }
           }
         }
@@ -249,38 +249,38 @@
     "externalDatabase": {
       "type": "object",
       "title": "External Database Details",
-      "description": "If MySQL is disabled. Use this section to specify the external database details",
+      "description": "If MariaDB is disabled. Use this section to specify the external database details",
       "form": true,
       "properties": {
         "host": {
           "type": "string",
           "form": true,
           "title": "Database Host",
-          "hidden": "mysql/enabled"
+          "hidden": "mariadb/enabled"
         },
         "user": {
           "type": "string",
           "form": true,
           "title": "Database Username",
-          "hidden": "mysql/enabled"
+          "hidden": "mariadb/enabled"
         },
         "password": {
           "type": "string",
           "form": true,
           "title": "Database Password",
-          "hidden": "mysql/enabled"
+          "hidden": "mariadb/enabled"
         },
         "database": {
           "type": "string",
           "form": true,
           "title": "Database Name",
-          "hidden": "mysql/enabled"
+          "hidden": "mariadb/enabled"
         },
         "port": {
           "type": "integer",
           "form": true,
           "title": "Database Port",
-          "hidden": "mysql/enabled"
+          "hidden": "mariadb/enabled"
         },
         "existingSecret": {
           "type": "string"

--- a/charts/yourls/values.yaml
+++ b/charts/yourls/values.yaml
@@ -712,39 +712,39 @@ metrics:
 
 ## @section Database Parameters
 
-## MySQL chart configuration
-## ref: https://github.com/bitnami/charts/blob/master/bitnami/mysql/values.yaml
+## MariaDB chart configuration
+## ref: https://github.com/bitnami/charts/blob/master/bitnami/mariadb/values.yaml
 ##
-mysql:
-  ## @param mysql.enabled Deploy a MySQL server to satisfy the application database requirements
+mariadb:
+  ## @param mariadb.enabled Deploy a MariaDB server to satisfy the applications database requirements
   ## To use an external database set this to false and configure the `externalDatabase.*` parameters
   ##
   enabled: true
-  ## @param mysql.architecture MySQL architecture. Allowed values: `standalone` or `replication`
+  ## @param mariadb.architecture MariaDB architecture. Allowed values: `standalone` or `replication`
   ##
   architecture: standalone
-  ## MySQL Authentication parameters
-  ## @param mysql.auth.rootPassword MySQL root password
-  ## @param mysql.auth.database MySQL custom database
-  ## @param mysql.auth.username MySQL custom username
-  ## @param mysql.auth.password MySQL custom user password
-  ## ref: https://github.com/bitnami/bitnami-docker-mysql#setting-the-root-password-on-first-run
-  ##      https://github.com/bitnami/bitnami-docker-mysql/blob/master/README.md#creating-a-database-on-first-run
-  ##      https://github.com/bitnami/bitnami-docker-mysql/blob/master/README.md#creating-a-database-user-on-first-run
+  ## MariaDB Authentication parameters
+  ## @param mariadb.auth.rootPassword MariaDB root password
+  ## @param mariadb.auth.database MariaDB custom database
+  ## @param mariadb.auth.username MariaDB custom user name
+  ## @param mariadb.auth.password MariaDB custom user password
+  ## ref: https://github.com/bitnami/bitnami-docker-mariadb#setting-the-root-password-on-first-run
+  ##      https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
+  ##      https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
   auth:
     rootPassword: ""
     database: yourls
     username: yourls
     password: ""
-  ## MySQL Primary configuration
+  ## MariaDB Primary configuration
   ##
   primary:
-    ## MySQL Primary Persistence parameters
+    ## MariaDB Primary Persistence parameters
     ## ref: https://kubernetes.io/docs/user-guide/persistent-volumes/
-    ## @param mysql.primary.persistence.enabled Enable persistence on MySQL using PVC(s)
-    ## @param mysql.primary.persistence.storageClass Persistent Volume storage class
-    ## @param mysql.primary.persistence.accessModes [array] Persistent Volume access modes
-    ## @param mysql.primary.persistence.size Persistent Volume size
+    ## @param mariadb.primary.persistence.enabled Enable persistence on MariaDB using PVC(s)
+    ## @param mariadb.primary.persistence.storageClass Persistent Volume storage class
+    ## @param mariadb.primary.persistence.accessModes [array] Persistent Volume access modes
+    ## @param mariadb.primary.persistence.size Persistent Volume size
     ##
     persistence:
       enabled: true
@@ -753,7 +753,7 @@ mysql:
         - ReadWriteOnce
       size: 8Gi
 ## External Database Configuration
-## All of these values are only used if `mysql.enabled=false`
+## All of these values are only used if `mariadb.enabled=false`
 ##
 externalDatabase:
   ## @param externalDatabase.host External Database server host
@@ -771,8 +771,8 @@ externalDatabase:
   ## @param externalDatabase.database External Database database name
   ##
   database: yourls
-  ## @param externalDatabase.existingSecret The name of an existing secret with database credentials
-  ## NOTE: Must contain key `mysql-password`
+  ## @param externalDatabase.existingSecret The name of an existing secret with database credentials. Evaluated as a template
+  ## NOTE: Must contain key `mariadb-password`
   ## NOTE: When it's set, the `externalDatabase.password` parameter is ignored
   ##
   existingSecret: ""


### PR DESCRIPTION
* Switch to MariaDB as database engine
  * Values namespace `mysql` rename to `mariadb`
  * Database chart values validation
  * Better usage & security support from upstream
* Chart upgrade validation