### PR TITLE
fix: extraEnvVars support

### DIFF
--- a/charts/yourls/Chart.yaml
+++ b/charts/yourls/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 5.8.13
+version: 5.8.14
 name: yourls
 description: Your Own URL Shortener
 appVersion: "1.9.2"

--- a/charts/yourls/templates/deployment.yaml
+++ b/charts/yourls/templates/deployment.yaml
@@ -148,6 +148,9 @@ spec:
               value: {{ .Values.containerPorts.http | quote }}
             - name: APACHE_HTTPS_PORT_NUMBER
               value: {{ .Values.containerPorts.https | quote }}
+            {{- if .Values.extraEnvVars }}
+              {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
           envFrom:
             {{- if .Values.extraEnvVarsCM }}
             - configMapRef:


### PR DESCRIPTION
It is possible to add `extraEnvVars` inside `values.yaml` but it was not implemented in `deployment.yaml`.
https://github.com/YOURLS/charts/blob/9145726e803144ba50b15f9c2566fe6968b85b61/charts/yourls/values.yaml#L146-L152

Very usefull for changing value of [api token signature](https://yourls.org/docs/guide/advanced/passwordless-api#reset-your-secret-signature-token)