### PR TITLE
Fix when update strategy type is recreate

### DIFF
--- a/charts/yourls/Chart.yaml
+++ b/charts/yourls/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 5.8.14
+version: 5.8.15
 name: yourls
 description: Your Own URL Shortener
 appVersion: "1.9.2"

--- a/charts/yourls/values.yaml
+++ b/charts/yourls/values.yaml
@@ -176,7 +176,6 @@ replicaCount: 1
 ##
 updateStrategy:
   type: RollingUpdate
-  rollingUpdate: {}
 ## @param schedulerName Alternate scheduler
 ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
 ##


### PR DESCRIPTION
Hello,

a small fix when you want to use an update strategy type to Recreate.
Below the kind of error without fix :
`Error: UPGRADE FAILED: cannot patch "yourls" with kind Deployment: Deployment.apps "yourls" is invalid: spec.strategy.rollingUpdate: Forbidden: may not be specified when strategy type is 'Recreate'`

If users want to add a specific RollingUpdate strategy, they had to put something like your values example
```
## updateStrategy:
##  type: RollingUpdate
##  rollingUpdate:
##    maxSurge: 25%
##    maxUnavailable: 25%
##
```
Otherwise no need to add `rollingUpdate: {}` as before.
