### PR TITLE
Ensure the presence of the port in database host variable

### DIFF
--- a/charts/yourls/Chart.yaml
+++ b/charts/yourls/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 7.0.5
+version: 7.0.6
 name: yourls
 description: Your Own URL Shortener
 # renovate: image=ghcr.io/yourls/yourls

--- a/charts/yourls/templates/deployment.yaml
+++ b/charts/yourls/templates/deployment.yaml
@@ -130,7 +130,7 @@ spec:
             - name: MARIADB_PORT_NUMBER
               value: {{ include "yourls.databasePort" . | quote }}
             - name: YOURLS_DB_HOST
-              value: {{ include "yourls.databaseHost" . | quote }}
+              value: "{{ include "yourls.databaseHost" . }}:{{ include "yourls.databasePort" . }}"
             - name: YOURLS_DB_NAME
               value: {{ include "yourls.databaseName" . | quote }}
             - name: YOURLS_DB_USER

--- a/charts/yourls/templates/deployment.yaml
+++ b/charts/yourls/templates/deployment.yaml
@@ -130,7 +130,7 @@ spec:
             - name: MARIADB_PORT_NUMBER
               value: {{ include "yourls.databasePort" . | quote }}
             - name: YOURLS_DB_HOST
-              value: "{{ include "yourls.databaseHost" . }}:{{ include "yourls.databasePort" . }}"
+              value: {{ printf "%s:%s" (include "yourls.databaseHost" .) (include "yourls.databasePort" .) }}
             - name: YOURLS_DB_NAME
               value: {{ include "yourls.databaseName" . | quote }}
             - name: YOURLS_DB_USER


### PR DESCRIPTION
Since Port is seperated for MARIADB variables, it needs to be joined for `YOURLS_DB_HOST`